### PR TITLE
Fix StackOverflowError when sending sounds.

### DIFF
--- a/src/me/libraryaddict/disguise/utilities/packetlisteners/PacketListenerSounds.java
+++ b/src/me/libraryaddict/disguise/utilities/packetlisteners/PacketListenerSounds.java
@@ -70,6 +70,8 @@ public class PacketListenerSounds extends PacketAdapter
             Location soundLoc = new Location(observer.getWorld(), ((Integer) mods.read(2)) / 8D, ((Integer) mods.read(3)) / 8D,
                     ((Integer) mods.read(4)) / 8D);
 
+            if (!soundLoc.getWorld().isChunkLoaded(soundLoc.getBlockX() / 16, soundLoc.getBlockZ() / 16)) return;
+
             Entity disguisedEntity = null;
             DisguiseSound entitySound = null;
 


### PR DESCRIPTION
Sometimes, when loading a chunk, the entities will send a sound (item frames in my case) before the chunk finishes loading. So when `PacketListenerSounds` tries to get that chunk, it hasn't been registered with the world yet. That means it will try to start loading the chunk... etc.

I fix it by not using the sound listener if the sound if the chunk isn't loaded.

Fixes #133.