### PR TITLE
Use the latest version of ProtocolLib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
+            <version>4.3.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>


### PR DESCRIPTION
Due to transitive dependencies and the fact ProtocolLib 4.2.0 is no longer available in any repos means any project that uses LibsDisguises fails to compile! This fixes that issue.