### PR TITLE
Fix md_5 maven repository warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         </repository>
         <repository>
             <id>md_5-releases</id>
-            <url>https://repo.md-5.net/content/repositories/releases/</url>
+            <url>https://repo.md-5.net/content/groups/public/</url>
         </repository>
         <repository>
             <id>spigot-repo</id>


### PR DESCRIPTION
Due to the way that Sonatype works, directly referencing the repository rather than the group that contains the dependencies you need does not work correctly, and causes Maven to complain that metadata is not supported when queries are made to the said repository. Examples of such can be found in the log attached here: [build.log](https://github.com/libraryaddict/LibsDisguises/files/4196380/build.log)

The simple fix is to replace the URL with the public group rather than a direct path to the releases repository. All warnings are resolved by doing so. :)

Just a minor thing, but figured I'd do this now because otherwise any other plugin which depends on LibsDisguises *also* then displays those warnings every time it tries to compile. :grimacing: 

Hope this helps! :))