### PR TITLE
Support latest ProtocolLib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@
             <version>1.18.10</version>
         </dependency>
         <dependency>
-            <groupId>com.comphenix.protocol</groupId>
+            <groupId>com.github.dmulloy2</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.5.0</version>
+            <version>master-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
@@ -112,8 +112,8 @@
 
     <repositories>
         <repository>
-            <id>dmulloy2-repo</id>
-            <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
         <repository>
             <id>md_5-releases</id>

--- a/src/main/java/me/libraryaddict/disguise/utilities/packets/packetlisteners/PacketListenerInventory.java
+++ b/src/main/java/me/libraryaddict/disguise/utilities/packets/packetlisteners/PacketListenerInventory.java
@@ -8,6 +8,7 @@ import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.reflect.StructureModifier;
+import com.comphenix.protocol.utility.ByteBuddyGenerated;
 import me.libraryaddict.disguise.DisguiseAPI;
 import me.libraryaddict.disguise.LibsDisguises;
 import me.libraryaddict.disguise.disguisetypes.Disguise;
@@ -44,7 +45,7 @@ public class PacketListenerInventory extends PacketAdapter {
         if (player.getName().contains("UNKNOWN[")) // If the player is temporary
             return;
 
-        if (player instanceof com.comphenix.net.sf.cglib.proxy.Factory || player.getVehicle() != null) {
+        if (player instanceof ByteBuddyGenerated || player.getVehicle() != null) {
             return;
         }
 
@@ -250,7 +251,7 @@ public class PacketListenerInventory extends PacketAdapter {
         Player player = event.getPlayer();
 
         // If the inventory is the players inventory
-        if (player instanceof com.comphenix.net.sf.cglib.proxy.Factory || player.getVehicle() != null ||
+        if (player instanceof ByteBuddyGenerated || player.getVehicle() != null ||
                 event.getPacket().getIntegers().read(0) != 0) {
             return;
         }


### PR DESCRIPTION
- Switched to JitPack for the ProtocolLib repository. See dmulloy2/ProtocolLib#1047.
- Using the new interface of generated classes when checking if a player is a proxy player. See dmulloy2/ProtocolLib#1053.