### PR TITLE
Disable auto updater by default

### DIFF
--- a/src/main/resources/configs/libsdisguises.yml
+++ b/src/main/resources/configs/libsdisguises.yml
@@ -10,7 +10,7 @@ Translations: false
 # Disabling this will also disable notifications when the plugin updated
 NotifyUpdate: true
 # Should the plugin automatically update?
-AutoUpdate: true
+AutoUpdate: false
 
 # Where should the plugin check for updates?
 # SAME_BUILDS - Will check snapshots if you're not using a release build


### PR DESCRIPTION
Auto Updater might be some nice feature but I have some issue with that. 42GB Logs because some change created a NPE every tick.

Please don't enable Auto Updater by default. I don't want to have plugins changed in a running system (never change a running system)