### PR TITLE
Fix ReflectionManager for 1.18.2

### DIFF
--- a/nms/v1_18_R2/src/main/java/me/libraryaddict/disguise/utilities/reflection/v1_18_2/ReflectionManager.java
+++ b/nms/v1_18_R2/src/main/java/me/libraryaddict/disguise/utilities/reflection/v1_18_2/ReflectionManager.java
@@ -452,7 +452,7 @@ public class ReflectionManager implements ReflectionManagerAbstract {
 
     public ItemMeta getDeserializedItemMeta(Map<String, Object> meta) {
         try {
-            Class<?> aClass = Class.forName("org.bukkit.craftbukkit.v1_18_R1.inventory.CraftMetaItem$SerializableMeta");
+            Class<?> aClass = Class.forName("org.bukkit.craftbukkit.v1_18_R2.inventory.CraftMetaItem$SerializableMeta");
             Method deserialize = aClass.getDeclaredMethod("deserialize", Map.class);
             Object itemMeta = deserialize.invoke(null, meta);
 


### PR DESCRIPTION
This PR fix #642 related to a bad reflection load in 1.18.2 (a bad copy-paste from 1.18.1).

Tested in local and works. 