### PR TITLE
Fixed specific help message with disguise commands

### DIFF
--- a/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguiseCommand.java
+++ b/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguiseCommand.java
@@ -134,13 +134,13 @@ public class DisguiseCommand extends DisguiseBaseCommand implements TabCompleter
         LibsMsg.DISG_HELP1.send(sender);
         LibsMsg.CAN_USE_DISGS.send(sender, StringUtils.join(allowedDisguises, LibsMsg.CAN_USE_DISGS_SEPERATOR.get()));
 
-        if (allowedDisguises.contains("player")) {
+        if (allowedDisguises.contains("Player")) {
             LibsMsg.DISG_HELP2.send(sender);
         }
 
         LibsMsg.DISG_HELP3.send(sender);
 
-        if (allowedDisguises.contains("dropped_item") || allowedDisguises.contains("falling_block")) {
+        if (allowedDisguises.contains("Dropped_item") || allowedDisguises.contains("Falling_block")) {
             LibsMsg.DISG_HELP4.send(sender);
         }
     }

--- a/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguiseEntityCommand.java
+++ b/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguiseEntityCommand.java
@@ -96,13 +96,13 @@ public class DisguiseEntityCommand extends DisguiseBaseCommand implements TabCom
         LibsMsg.DISG_ENT_HELP1.send(sender);
         LibsMsg.CAN_USE_DISGS.send(sender, StringUtils.join(allowedDisguises, LibsMsg.CAN_USE_DISGS_SEPERATOR.get()));
 
-        if (allowedDisguises.contains("player")) {
+        if (allowedDisguises.contains("Player")) {
             LibsMsg.DISG_ENT_HELP3.send(sender);
         }
 
         LibsMsg.DISG_ENT_HELP4.send(sender);
 
-        if (allowedDisguises.contains("dropped_item") || allowedDisguises.contains("falling_block")) {
+        if (allowedDisguises.contains("Dropped_item") || allowedDisguises.contains("Falling_block")) {
             LibsMsg.DISG_ENT_HELP5.send(sender);
         }
     }

--- a/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguisePlayerCommand.java
+++ b/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguisePlayerCommand.java
@@ -180,13 +180,13 @@ public class DisguisePlayerCommand extends DisguiseBaseCommand implements TabCom
         LibsMsg.D_HELP1.send(sender);
         LibsMsg.CAN_USE_DISGS.send(sender, StringUtils.join(allowedDisguises, LibsMsg.CAN_USE_DISGS_SEPERATOR.get()));
 
-        if (allowedDisguises.contains("player")) {
+        if (allowedDisguises.contains("Player")) {
             LibsMsg.D_HELP3.send(sender);
         }
 
         LibsMsg.D_HELP4.send(sender);
 
-        if (allowedDisguises.contains("dropped_item") || allowedDisguises.contains("falling_block")) {
+        if (allowedDisguises.contains("Dropped_item") || allowedDisguises.contains("Falling_block")) {
             LibsMsg.D_HELP5.send(sender);
         }
     }

--- a/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguiseRadiusCommand.java
+++ b/plugin/src/main/java/me/libraryaddict/disguise/commands/disguise/DisguiseRadiusCommand.java
@@ -290,13 +290,13 @@ public class DisguiseRadiusCommand extends DisguiseBaseCommand implements TabCom
         LibsMsg.DRADIUS_HELP1.send(sender, DisguiseConfig.getDisguiseRadiusMax());
         LibsMsg.CAN_USE_DISGS.send(sender, StringUtils.join(allowedDisguises, LibsMsg.CAN_USE_DISGS_SEPERATOR.get()));
 
-        if (allowedDisguises.contains("player")) {
+        if (allowedDisguises.contains("Player")) {
             LibsMsg.DRADIUS_HELP3.send(sender);
         }
 
         LibsMsg.DRADIUS_HELP4.send(sender);
 
-        if (allowedDisguises.contains("dropped_item") || allowedDisguises.contains("falling_block")) {
+        if (allowedDisguises.contains("Dropped_item") || allowedDisguises.contains("Falling_block")) {
             LibsMsg.DRADIUS_HELP5.send(sender);
         }
 


### PR DESCRIPTION
The default disguise names start with an upper case letter. Some help messages are never shown.