### PR TITLE
Make spigot dependencies optional in plugin pom

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -131,10 +131,12 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
+            <optional>true</optional>
         </dependency>
         <!-- testing -->
         <dependency>


### PR DESCRIPTION
I noticed while importing LibsDisguises, the spigot dependencies were being added to my classpath. This PR aims to remedy this behavior by making the spigot dependencies optional. The following is my dependency in maven.
````
            <dependency>
                <groupId>LibsDisguises</groupId>
                <artifactId>LibsDisguises</artifactId>
                <version>10.0.35-SNAPSHOT</version>
                <scope>provided</scope>
            </dependency>