### PR TITLE
Add underscores as a valid MineSkin API key character

### DIFF
--- a/plugin/src/main/java/me/libraryaddict/disguise/DisguiseConfig.java
+++ b/plugin/src/main/java/me/libraryaddict/disguise/DisguiseConfig.java
@@ -784,7 +784,7 @@ public class DisguiseConfig {
         setUniquePlayerDisguiseUUIDs(config.getBoolean("UniquePlayerUUID"));
         setHideDeathMessages(config.getBoolean("HideDeathMessages"));
 
-        if (apiKey != null && apiKey.matches("[a-zA-Z\\d]{8,}")) {
+        if (apiKey != null && apiKey.matches("[a-zA-Z\\d_]{8,}")) {
             DisguiseUtilities.getMineSkinAPI().setApiKey(apiKey);
         } else if (apiKey != null && apiKey.length() > 8) {
             LibsDisguises.getInstance().getLogger().warning("API Key provided for MineSkin does not appear to be in a valid format!");


### PR DESCRIPTION
Currently, providing a MineSkin API key will result in this warning message:

> API Key provided for MineSkin does not appear to be in a valid format!

despite the key being valid. This is because the validation regex `[a-zA-Z\\d]{8,}` does not match underscores (see [MineSkin documentation](https://docs.mineskin.org/docs/guides/getting-started#api-key) for an example of an API key). Simply adding an underscore fixes the issue.