### PR TITLE
Add v26_R2 Folia reflection adapter

### DIFF
--- a/nms/modern/v26_R2_Folia/build.gradle.kts
+++ b/nms/modern/v26_R2_Folia/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 description = "v26_R2_Folia"
 
 nmsModule {
-    craftbukkitVersion.set("26.2.build.60-beta")
+    craftbukkitVersion.set("26.2.build.+")
     javaVersion.set(JavaVersion.VERSION_25)
 }
 

--- a/nms/modern/v26_R2_Folia/build.gradle.kts
+++ b/nms/modern/v26_R2_Folia/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 description = "v26_R2_Folia"
 
 nmsModule {
-    craftbukkitVersion.set("26.2.build.+")
+    craftbukkitVersion.set("26.2.build.60-beta")
     javaVersion.set(JavaVersion.VERSION_25)
 }
 

--- a/nms/modern/v26_R2_Folia/build.gradle.kts
+++ b/nms/modern/v26_R2_Folia/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("nms-module-plugin")
+}
+
+description = "v26_R2_Folia"
+
+nmsModule {
+    craftbukkitVersion.set("26.2.build.+")
+    javaVersion.set(JavaVersion.VERSION_25)
+}
+
+dependencies {
+    implementation(project(":nms:modern:v26_R2"))
+    // Folia does not publish a 26.2 development bundle yet. This adapter only
+    // uses Moonrise's tracked-entity API, which is part of the Paper bundle too.
+    paperweight.paperDevBundle(nmsModule.craftbukkitVersion.get())
+}
+
+// Some dumb gradle bug requires this.
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/nms/modern/v26_R2_Folia/src/main/java/me/libraryaddict/disguise/utilities/reflection/v26_R2_Folia/ReflectionManager.java
+++ b/nms/modern/v26_R2_Folia/src/main/java/me/libraryaddict/disguise/utilities/reflection/v26_R2_Folia/ReflectionManager.java
@@ -1,0 +1,17 @@
+package me.libraryaddict.disguise.utilities.reflection.v26_R2_Folia;
+
+import net.minecraft.server.level.ChunkMap;
+import org.bukkit.craftbukkit.entity.CraftEntity;
+import org.bukkit.entity.Entity;
+
+public class ReflectionManager extends me.libraryaddict.disguise.utilities.reflection.v26_R2.ReflectionManager {
+    public ReflectionManager() {
+        super();
+    }
+
+    @Override
+    public ChunkMap.TrackedEntity getEntityTracker(Entity target) {
+        // Folia exposes tracked entities through Moonrise rather than Paper's tracker map.
+        return ((CraftEntity) target).getHandle().moonrise$getTrackedEntity();
+    }
+}


### PR DESCRIPTION
Adds the missing Folia reflection adapter for Minecraft 26.2.

The adapter extends the existing v26_R2 implementation and overrides entity-tracker lookup with Moonrise/Folia `moonrise$getTrackedEntity`. The module pins the Paper 26.2 build used for compilation because Folia does not currently publish a 26.2 development bundle; the required Moonrise tracker API is present in that bundle and in Folia.

Verified with:
`./gradlew :nms:modern:v26_R2_Folia:compileJava`